### PR TITLE
add svg limits from asset api

### DIFF
--- a/limits.json
+++ b/limits.json
@@ -22,5 +22,10 @@
     },
     "serialtiles": {
         "max_tilesize": 512000
+    },
+    "svg": {
+        "max_filesize": 125000,
+        "max_width": 512,
+        "max_height": 512
     }
 }


### PR DESCRIPTION
fix https://github.com/mapbox/mapbox-upload-limits/issues/1