### PR TITLE
Bump up limits for GeoJSON/CSV uploads

### DIFF
--- a/limits.json
+++ b/limits.json
@@ -8,10 +8,10 @@
         "max_filesize": 10737418240
     },
     "csv": {
-        "max_filesize": 5242880
+        "max_filesize": 10737418240
     },
     "omnivoreOther": {
-        "max_filesize": 272629760
+        "max_filesize": 10737418240
     },
     "tm2z": {
         "max_metadata": 61440,

--- a/limits.json
+++ b/limits.json
@@ -10,6 +10,9 @@
     "csv": {
         "max_filesize": 10737418240
     },
+    "geojson": {
+        "max_filesize": 10737418240
+    },
     "omnivoreOther": {
         "max_filesize": 10737418240
     },

--- a/limits.json
+++ b/limits.json
@@ -8,13 +8,13 @@
         "max_filesize": 10737418240
     },
     "csv": {
-        "max_filesize": 10737418240
+        "max_filesize": 1073741824
     },
     "geojson": {
-        "max_filesize": 10737418240
+        "max_filesize": 1073741824
     },
     "omnivoreOther": {
-        "max_filesize": 10737418240
+        "max_filesize": 272629760
     },
     "tm2z": {
         "max_metadata": 61440,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-upload-limits",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "limits for the mapbox data upload api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Per https://github.com/mapbox/unpacker/issues/663

After testing indexed geojson/csv uploads in staging, I'm comfortable with bumping both up to 1GB.

cc @springmeyer 