### PR TITLE
Set max filesize for all types.

### DIFF
--- a/limits.json
+++ b/limits.json
@@ -1,5 +1,6 @@
 {
     "mbtiles": {
+        "max_filesize": 10737418240,
         "max_tilesize": 512000,
         "max_gridsize": 512000,
         "max_totalitems": 30000000
@@ -14,6 +15,7 @@
         "max_filesize": 272629760
     },
     "tm2z": {
+        "max_filesize": 20971520,
         "max_metadata": 61440,
         "max_drawtime": 1000,
         "avg_drawtime": 300,
@@ -21,6 +23,7 @@
         "avg_imgbytes": 51200
     },
     "serialtiles": {
+        "max_filesize": 10737418240,
         "max_tilesize": 512000
     },
     "svg": {


### PR DESCRIPTION
Capture `max_filesize` for `mbtiles`, `tm2z`, and `serialtiles`.

/cc @rclark 