### PR TITLE
Increase tif `max_filesize`

### DIFF
--- a/limits.json
+++ b/limits.json
@@ -6,7 +6,7 @@
         "max_totalitems": 30000000
     },
     "tif": {
-        "max_filesize": 10737418240
+        "max_filesize": 35000000000
     },
     "csv": {
         "max_filesize": 1073741824

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-upload-limits",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "limits for the mapbox data upload api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows unpacker to consume the ~1cm, z16 tifs. Currently, these tifs are being rejected on account of being larger than ~10.7g.